### PR TITLE
separated API endpoints for web and native to correctly handle CSRF

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -21,6 +21,7 @@
            mount                               {:mvn/version "0.1.16"}
            ring/ring-core                      {:mvn/version "1.7.0"}
            ring/ring-defaults                  {:mvn/version "0.3.2"}
+           metosin/reitit-ring                 {:mvn/version "0.4.2"}
 
            ;; logging
            com.taoensso/timbre                 {:mvn/version "4.10.0"}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,7 +14,7 @@
             {:target     :react-native
              :init-fn    app.client-native/init
              :output-dir "mobile/app"
-             :dev        {:closure-defines {app.client-native/SERVER_URL "http://localhost:3000/api"}}
+             :dev        {:closure-defines {app.client-native/SERVER_URL "http://localhost:3000/api-native"}}
              :release    {:compiler-options {:optimizations     :simple
                                              :infer-externs     :auto
                                              :variable-renaming :off

--- a/src/main/app/client.cljs
+++ b/src/main/app/client.cljs
@@ -11,6 +11,11 @@
     [taoensso.timbre :as log]
     [com.fulcrologic.fulcro.routing.dynamic-routing :as dr]))
 
+(def secured-request-middleware
+  (->
+    (net/wrap-csrf-token (or (.-fulcro_network_csrf_token js/window) "TOKEN-NOT-IN-HTML!"))
+    (net/wrap-fulcro-request)))
+
 (defn ^:export refresh []
   (log/info "Hot code Remount")
   (cssi/upsert-css "componentcss" {:component root/Root})
@@ -19,7 +24,9 @@
 (defn ^:export init []
   (log/info "Application starting.")
   (reset! SPA (app/fulcro-app
-                {:remotes {:remote (net/fulcro-http-remote {:url "/api"})}}))
+                {:remotes {:remote (net/fulcro-http-remote
+                                     {:url                "/api"
+                                      :request-middleware secured-request-middleware})}}))
   (cssi/upsert-css "componentcss" {:component root/Root})
   (app/set-root! @SPA root/Root {:initialize-state? true})
   (dr/initialize! @SPA)

--- a/src/main/app/client_native.cljs
+++ b/src/main/app/client_native.cljs
@@ -11,7 +11,7 @@
     [app.model.session :as session]))
 
 ;; See defines in shadow-cljs for dev mode
-(goog-define SERVER_URL "http://production.server.com/api")
+(goog-define SERVER_URL "http://production.server.com/api-native")
 
 (defn ^:export start
   {:dev/after-load true}

--- a/src/main/app/server_components/middleware.clj
+++ b/src/main/app/server_components/middleware.clj
@@ -22,7 +22,6 @@
      :body    "NOPE"}))
 
 (defn api-handler [request]
-  (log/spy :info request)
   (handle-api-request
     (:transit-params request)
     (fn [tx] (parser {:ring/request request} tx))))

--- a/src/main/app/server_components/middleware.clj
+++ b/src/main/app/server_components/middleware.clj
@@ -9,11 +9,11 @@
     [reitit.ring :as ring]
     [ring.middleware.defaults :refer [wrap-defaults]]
     [ring.middleware.gzip :refer [wrap-gzip]]
+    [ring.middleware.session.memory :as mem]
     [ring.util.response :refer [response file-response resource-response]]
     [ring.util.response :as resp]
     [hiccup.page :refer [html5]]
-    [taoensso.timbre :as log]
-    [ring.middleware.session.memory :as mem]))
+    [taoensso.timbre :as log]))
 
 (def ^:private not-found-handler
   (fn [req]

--- a/src/main/app/server_components/middleware.clj
+++ b/src/main/app/server_components/middleware.clj
@@ -6,12 +6,14 @@
     [com.fulcrologic.fulcro.server.api-middleware :refer [handle-api-request
                                                           wrap-transit-params
                                                           wrap-transit-response]]
+    [reitit.ring :as ring]
     [ring.middleware.defaults :refer [wrap-defaults]]
     [ring.middleware.gzip :refer [wrap-gzip]]
     [ring.util.response :refer [response file-response resource-response]]
     [ring.util.response :as resp]
     [hiccup.page :refer [html5]]
-    [taoensso.timbre :as log]))
+    [taoensso.timbre :as log]
+    [ring.middleware.session.memory :as mem]))
 
 (def ^:private not-found-handler
   (fn [req]
@@ -19,20 +21,17 @@
      :headers {"Content-Type" "text/plain"}
      :body    "NOPE"}))
 
-(defn wrap-api [handler uri]
-  (fn [request]
-    (log/spy :info request)
-    (if (= uri (:uri request))
-      (handle-api-request
-        (:transit-params request)
-        (fn [tx] (parser {:ring/request request} tx)))
-      (handler request))))
+(defn api-handler [request]
+  (log/spy :info request)
+  (handle-api-request
+    (:transit-params request)
+    (fn [tx] (parser {:ring/request request} tx))))
 
 ;; ================================================================================
 ;; Dynamically generated HTML. We do this so we can safely embed the CSRF token
 ;; in a js var for use by the client.
 ;; ================================================================================
-(defn index []
+(defn index [{:keys [anti-forgery-token]}]
   (log/debug "Serving index.html")
   (html5
     [:html {:lang "en"}
@@ -42,32 +41,41 @@
       [:meta {:name "viewport" :content "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"}]
       [:link {:href "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css"
               :rel  "stylesheet"}]
-      [:link {:rel "shortcut icon" :href "data:image/x-icon;," :type "image/x-icon"}]]
+      [:link {:rel "shortcut icon" :href "data:image/x-icon;," :type "image/x-icon"}]
+      [:script (str "var fulcro_network_csrf_token = '" anti-forgery-token "';")]]
      [:body
       [:div#app]
       [:script {:src "js/main/main.js"}]]]))
 
-(defn wrap-html-routes [ring-handler]
-  (fn [{:keys [uri] :as req}]
-    (cond
-      (#{"/" "/index.html"} uri)
-      (-> (resp/response (index))
-        (resp/content-type "text/html"))
-
-      :else
-      (ring-handler req))))
-
 (defstate middleware
   :start
-  (let [defaults-config (:ring.middleware/defaults-config config)]
-    (-> not-found-handler
-      (wrap-api "/api")
-      wrap-transit-params
-      wrap-transit-response
-      (wrap-html-routes)
-      ;; If you want to set something like session store, you'd do it against
-      ;; the defaults-config here (which comes from an EDN file, so it can't have
-      ;; code initialized).
-      ;; E.g. (wrap-defaults (assoc-in defaults-config [:session :store] (my-store)))
-      (wrap-defaults defaults-config)
-      wrap-gzip)))
+  (let [session-store          (mem/memory-store)
+        defaults-config        (-> (:ring.middleware/defaults-config config)
+                                 ;; If you want to set something like session store, you'd do it against
+                                 ;; the defaults-config here (which comes from an EDN file, so it can't have
+                                 ;; code initialized).
+                                 (assoc-in [:session :store] session-store))
+        defaults-config-native (-> defaults-config
+                                 ;; CSRF makes sense only in browser, so we disable it for native
+                                 ;; and change cookie name to prevent CSRF against this endpoint
+                                 (assoc-in [:security :anti-forgery] false)
+                                 (update-in [:session :cookie-name] str "-native"))]
+    (ring/ring-handler
+      (ring/router
+        [["/api"
+          {:middleware [#(wrap-defaults % defaults-config)
+                        wrap-transit-response
+                        wrap-transit-params]
+           :post       {:summary "Fulcro API"
+                        :handler api-handler}}]
+         ["/api-native"
+          {:middleware [#(wrap-defaults % defaults-config-native)
+                        wrap-transit-response
+                        wrap-transit-params]
+           :post       {:summary "Fulcro API for Native"
+                        :handler api-handler}}]])
+      (-> (fn [req]
+            (-> (resp/response (index req))
+              (resp/content-type "text/html")))
+        (wrap-defaults defaults-config))
+      {:middleware [wrap-gzip]})))

--- a/src/main/config/defaults.edn
+++ b/src/main/config/defaults.edn
@@ -1,37 +1,37 @@
-{:legal-origins              #{"localhost" "dev.lvh.me"}
+{:legal-origins             #{"localhost" "dev.lvh.me"}
 
  :org.httpkit.server/config {:port 3000}
 
  :taoensso.timbre/logging-config
-                             {:level        :info
-                              :ns-whitelist []
-                              :ns-blacklist ["datomic.kv-cluster"
-                                             "datomic.process-monitor"
-                                             "datomic.reconnector2"
-                                             "datomic.common"
-                                             "datomic.peer"
-                                             "datomic.log"
-                                             "datomic.db"
-                                             "datomic.slf4j"
-                                             "org.projectodd.wunderboss.web.Web"
-                                             "shadow.cljs.devtools.server.worker.impl"]}
+                            {:level        :info
+                             :ns-whitelist []
+                             :ns-blacklist ["datomic.kv-cluster"
+                                            "datomic.process-monitor"
+                                            "datomic.reconnector2"
+                                            "datomic.common"
+                                            "datomic.peer"
+                                            "datomic.log"
+                                            "datomic.db"
+                                            "datomic.slf4j"
+                                            "org.projectodd.wunderboss.web.Web"
+                                            "shadow.cljs.devtools.server.worker.impl"]}
 
  ;; The ssl-redirect defaulted to off, but for security should probably be on in production.
  :ring.middleware/defaults-config
-                             {:params    {:keywordize true
-                                          :multipart  true
-                                          :nested     true
-                                          :urlencoded true}
-                              :cookies   true
-                              :responses {:absolute-redirects     true
-                                          :content-types          true
-                                          :default-charset        "utf-8"
-                                          :not-modified-responses true}
-                              :static    {:resources "public"}
-                              :session   true
-                              :security  {:anti-forgery   false
-                                          :hsts           true
-                                          :ssl-redirect   false
-                                          :frame-options  :sameorigin
-                                          :xss-protection {:enable? true
-                                                           :mode    :block}}}}
+                            {:params    {:keywordize true
+                                         :multipart  true
+                                         :nested     true
+                                         :urlencoded true}
+                             :cookies   true
+                             :responses {:absolute-redirects     true
+                                         :content-types          true
+                                         :default-charset        "utf-8"
+                                         :not-modified-responses true}
+                             :static    {:resources "public"}
+                             :session   {:cookie-name "app-session"}
+                             :security  {:anti-forgery   true
+                                         :hsts           true
+                                         :ssl-redirect   false
+                                         :frame-options  :sameorigin
+                                         :xss-protection {:enable? true
+                                                          :mode    :block}}}}

--- a/src/main/config/defaults.edn
+++ b/src/main/config/defaults.edn
@@ -1,37 +1,37 @@
-{:legal-origins             #{"localhost" "dev.lvh.me"}
+{:legal-origins              #{"localhost" "dev.lvh.me"}
 
  :org.httpkit.server/config {:port 3000}
 
  :taoensso.timbre/logging-config
-                            {:level        :info
-                             :ns-whitelist []
-                             :ns-blacklist ["datomic.kv-cluster"
-                                            "datomic.process-monitor"
-                                            "datomic.reconnector2"
-                                            "datomic.common"
-                                            "datomic.peer"
-                                            "datomic.log"
-                                            "datomic.db"
-                                            "datomic.slf4j"
-                                            "org.projectodd.wunderboss.web.Web"
-                                            "shadow.cljs.devtools.server.worker.impl"]}
+                             {:level        :info
+                              :ns-whitelist []
+                              :ns-blacklist ["datomic.kv-cluster"
+                                             "datomic.process-monitor"
+                                             "datomic.reconnector2"
+                                             "datomic.common"
+                                             "datomic.peer"
+                                             "datomic.log"
+                                             "datomic.db"
+                                             "datomic.slf4j"
+                                             "org.projectodd.wunderboss.web.Web"
+                                             "shadow.cljs.devtools.server.worker.impl"]}
 
  ;; The ssl-redirect defaulted to off, but for security should probably be on in production.
  :ring.middleware/defaults-config
-                            {:params    {:keywordize true
-                                         :multipart  true
-                                         :nested     true
-                                         :urlencoded true}
-                             :cookies   true
-                             :responses {:absolute-redirects     true
-                                         :content-types          true
-                                         :default-charset        "utf-8"
-                                         :not-modified-responses true}
-                             :static    {:resources "public"}
-                             :session   {:cookie-name "app-session"}
-                             :security  {:anti-forgery   true
-                                         :hsts           true
-                                         :ssl-redirect   false
-                                         :frame-options  :sameorigin
-                                         :xss-protection {:enable? true
-                                                          :mode    :block}}}}
+                             {:params    {:keywordize true
+                                          :multipart  true
+                                          :nested     true
+                                          :urlencoded true}
+                              :cookies   true
+                              :responses {:absolute-redirects     true
+                                          :content-types          true
+                                          :default-charset        "utf-8"
+                                          :not-modified-responses true}
+                              :static    {:resources "public"}
+                              :session   {:cookie-name "app-session"}
+                              :security  {:anti-forgery   true
+                                          :hsts           true
+                                          :ssl-redirect   false
+                                          :frame-options  :sameorigin
+                                          :xss-protection {:enable? true
+                                                           :mode    :block}}}}


### PR DESCRIPTION
Native apps don't have a notion of CSRF, so we need to distinguish between requests from the browser and requests from native apps. The most straightforward approach is to create separate endpoints with CSRF enabled for web and disabled for native. To avoid request forgery against native endpoint from the browser we are separating their cookies.

I tried to make the minimal intrusion into the current template, but as we need to have different set of middlewares for different routes, it seems reasonable to introduce some basic routing facility (reitit in this case).

I also had to manually inject session store, as `wrap-defaults` is called multiple times and otherwise it would create a new store for each call.