### PR TITLE
added guardrails for clj/cljs

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,6 +4,7 @@
            com.fulcrologic/fulcro              {:mvn/version "3.0.4"}
            com.fulcrologic/fulcro-native       {:mvn/version "0.0.1-alpha"}
            com.fulcrologic/fulcro-garden-css   {:mvn/version "3.0.6"}
+           com.fulcrologic/guardrails          {:mvn/version "0.0.11"}
            garden                              {:mvn/version "1.3.9"}
            com.fulcrologic/semantic-ui-wrapper {:mvn/version "1.0.0"}
            edn-query-language/eql              {:mvn/version "0.0.8"}
@@ -29,5 +30,6 @@
                                com.fulcrologic/semantic-ui-wrapper {:mvn/version "1.0.0"}
                                binaryage/devtools                  {:mvn/version "0.9.10"}}}
            :dev  {:extra-paths ["src/dev"]
+                  :jvm-opts    ["-Dguardrails.enabled=true"]
                   :extra-deps  {org.clojure/tools.namespace {:mvn/version "0.3.1"}
                                 thheller/shadow-cljs        {:mvn/version "2.8.62"}}}}}

--- a/guardrails.edn
+++ b/guardrails.edn
@@ -1,0 +1,5 @@
+{:defn-macro nil
+ :throw?     false
+ :emit-spec? true
+ :expound    {:show-valid-values? true
+              :print-specs?       true}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,6 +7,8 @@
              :asset-path "/js/main"
              :modules    {:main {:init-fn app.client/init
                                  :entries [app.client]}}
+             :dev        {:closure-defines  {'goog.DEBUG true}
+                          :compiler-options {:external-config {:guardrails {}}}}
              :devtools   {:after-load app.client/refresh
                           :preloads   [com.fulcrologic.fulcro.inspect.preload app.development-preload]}}
 
@@ -14,7 +16,9 @@
             {:target     :react-native
              :init-fn    app.client-native/init
              :output-dir "mobile/app"
-             :dev        {:closure-defines {app.client-native/SERVER_URL "http://localhost:3000/api"}}
+             :dev        {:closure-defines  {'goog.DEBUG                  true
+                                             app.client-native/SERVER_URL "http://localhost:3000/api"}
+                          :compiler-options {:external-config {:guardrails {}}}}
              :release    {:compiler-options {:optimizations     :simple
                                              :infer-externs     :auto
                                              :variable-renaming :off

--- a/src/main/app/util.cljc
+++ b/src/main/app/util.cljc
@@ -1,7 +1,8 @@
 (ns app.util
   #?(:cljs (:refer-clojure :exclude [uuid]))
-  (:require [ghostwheel.core :refer [>defn]]
-            [clojure.spec.alpha :as s]))
+  (:require
+    [com.fulcrologic.guardrails.core :refer [>defn =>]]
+    [clojure.spec.alpha :as s]))
 
 (>defn uuid
   "Generate a UUID the same way via clj/cljs.  Without args gives random UUID. With args, builds UUID based on input (which


### PR DESCRIPTION
- Both CLJ and CLJS seem to work.
- I wasn't able to trigger guardrails to throw when calling spec'ed fn from CLJS REPL, but that's probably more about guardrails itself. Triggering guardrails-spec'ed fn from CLJS _code_ throws just fine.
- In case of CLJS guardrails effectively enabled both in `deps.edn` dev alias (CLJ + CLJS compiler) and in shadow-cljs.edn. Otherwise we'd need to refactor deps.edn a bit (move CLJS compiler to another alias), but that's probably fine?