### PR TITLE
separated API endpoints; enabled cookies for native

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -14,9 +14,8 @@ available on https://youtu.be/03I9uRxVQsc[YouTube].
 
 == Basic Usage
 
-IMPORTANT: If you want to use Electron Fulcro Inspect with
-the native app, you must uncomment the
-preload line in `shadow-cljs.edn`.
+IMPORTANT: By default native app will try to connect to Electron Fulcro Inspect.
+You may comment out the app.inspect-native-preload in `shadow-cljs.edn` to disable this.
 
 NOTE: Logging errors in the Native env will show
 an error screen on the app. Just press ESC to

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths   ["src/main" "resources"]
  :deps    {org.clojure/clojure                 {:mvn/version "1.10.1"}
            org.clojure/clojurescript           {:mvn/version "1.10.597"}
-           com.fulcrologic/fulcro              {:mvn/version "3.1.7"}
+           com.fulcrologic/fulcro              {:mvn/version "3.1.8"}
            com.fulcrologic/fulcro-native       {:mvn/version "0.0.5"}
            com.fulcrologic/fulcro-garden-css   {:mvn/version "3.0.7"}
            com.fulcrologic/guardrails          {:mvn/version "0.0.11"}
@@ -27,7 +27,8 @@
            ;; logging
            com.taoensso/timbre                 {:mvn/version "4.10.0"}}
 
- :aliases {:cljs {:extra-deps {com.cognitect/transit-cljs          {:mvn/version "0.8.256"}
+ :aliases {:cljs {:jvm-opts   ["-DSENTE_ELIDE_JS_REQUIRE=true"]
+                  :extra-deps {com.cognitect/transit-cljs          {:mvn/version "0.8.256"}
                                com.fulcrologic/semantic-ui-wrapper {:mvn/version "1.0.0"}
                                binaryage/devtools                  {:mvn/version "0.9.10"}}}
            :dev  {:extra-paths ["src/dev"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,9 @@
 {:paths   ["src/main" "resources"]
  :deps    {org.clojure/clojure                 {:mvn/version "1.10.1"}
-           org.clojure/clojurescript           {:mvn/version "1.10.520"}
-           com.fulcrologic/fulcro              {:mvn/version "3.0.4"}
-           com.fulcrologic/fulcro-native       {:mvn/version "0.0.1-alpha"}
-           com.fulcrologic/fulcro-garden-css   {:mvn/version "3.0.6"}
+           org.clojure/clojurescript           {:mvn/version "1.10.597"}
+           com.fulcrologic/fulcro              {:mvn/version "3.1.7"}
+           com.fulcrologic/fulcro-native       {:mvn/version "0.0.5"}
+           com.fulcrologic/fulcro-garden-css   {:mvn/version "3.0.7"}
            com.fulcrologic/guardrails          {:mvn/version "0.0.11"}
            garden                              {:mvn/version "1.3.9"}
            com.fulcrologic/semantic-ui-wrapper {:mvn/version "1.0.0"}
@@ -22,6 +22,7 @@
            mount                               {:mvn/version "0.1.16"}
            ring/ring-core                      {:mvn/version "1.7.0"}
            ring/ring-defaults                  {:mvn/version "0.3.2"}
+           metosin/reitit-ring                 {:mvn/version "0.4.2"}
 
            ;; logging
            com.taoensso/timbre                 {:mvn/version "4.10.0"}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -17,7 +17,7 @@
              :init-fn    app.client-native/init
              :output-dir "mobile/app"
              :dev        {:closure-defines  {'goog.DEBUG                  true
-                                             app.client-native/SERVER_URL "http://localhost:3000/api"}
+                                             app.client-native/SERVER_URL "http://localhost:3000/api-native"}
                           :compiler-options {:external-config {:guardrails {}}}}
              :release    {:compiler-options {:optimizations     :simple
                                              :infer-externs     :auto

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -28,7 +28,4 @@
              :js-options {:node-modules-dir "mobile/node_modules"}
              :devtools   {:autoload   true
                           :after-load app.client-native/start
-                          :preloads   [shadow.expo.keep-awake
-                                       ;; Uncomment the following line if you're running Fulcro Inspect Electron
-                                       ;com.fulcrologic.fulcro.inspect.websocket-preload
-                                       ]}}}}
+                          :preloads   [shadow.expo.keep-awake app.inspect-native-preload]}}}}

--- a/src/main/app/client.cljs
+++ b/src/main/app/client.cljs
@@ -11,6 +11,11 @@
     [taoensso.timbre :as log]
     [com.fulcrologic.fulcro.routing.dynamic-routing :as dr]))
 
+(def secured-request-middleware
+  (->
+    (net/wrap-csrf-token (or (.-fulcro_network_csrf_token js/window) "TOKEN-NOT-IN-HTML!"))
+    (net/wrap-fulcro-request)))
+
 (defn ^:export refresh []
   (log/info "Hot code Remount")
   (cssi/upsert-css "componentcss" {:component root/Root})
@@ -19,7 +24,9 @@
 (defn ^:export init []
   (log/info "Application starting.")
   (reset! SPA (app/fulcro-app
-                {:remotes {:remote (net/fulcro-http-remote {:url "/api"})}}))
+                {:remotes {:remote (net/fulcro-http-remote
+                                     {:url                "/api"
+                                      :request-middleware secured-request-middleware})}}))
   (cssi/upsert-css "componentcss" {:component root/Root})
   (app/set-root! @SPA root/Root {:initialize-state? true})
   (dr/initialize! @SPA)

--- a/src/main/app/client_native.cljs
+++ b/src/main/app/client_native.cljs
@@ -11,7 +11,7 @@
     [app.model.session :as session]))
 
 ;; See defines in shadow-cljs for dev mode
-(goog-define SERVER_URL "http://production.server.com/api")
+(goog-define SERVER_URL "http://production.server.com/api-native")
 
 (defn ^:export start
   {:dev/after-load true}
@@ -25,5 +25,7 @@
                                      (uism/begin! app session/session-machine ::session/session
                                        {:actor/login-form      root/Login
                                         :actor/current-session session/Session}))
-                 :remotes          {:remote (net/fulcro-http-remote {:url SERVER_URL})}}))
+                 :remotes          {:remote (net/fulcro-http-remote {:url        SERVER_URL
+                                                                     :make-xhrio #(doto (net/make-xhrio)
+                                                                                    (.setWithCredentials true))})}}))
   (start))

--- a/src/main/app/inspect_native_preload.cljs
+++ b/src/main/app/inspect_native_preload.cljs
@@ -1,0 +1,11 @@
+(ns app.inspect-native-preload
+  (:require
+    [com.fulcrologic.fulcro.inspect.inspect-client :as inspect]
+    [com.fulcrologic.fulcro.inspect.inspect-ws :as inspect-ws]
+    [taoensso.timbre :as log]))
+
+(when-not @inspect/started?*
+  (log/info "Installing Fulcro 3.x Inspect over Websockets targeting port " inspect-ws/SERVER_PORT)
+  (reset! inspect/started?* true)
+  ;; Workaround for https://github.com/ptaoussanis/sente/issues/361
+  (inspect-ws/start-ws-messaging! {:channel-type :ajax}))

--- a/src/main/app/server_components/middleware.clj
+++ b/src/main/app/server_components/middleware.clj
@@ -6,8 +6,10 @@
     [com.fulcrologic.fulcro.server.api-middleware :refer [handle-api-request
                                                           wrap-transit-params
                                                           wrap-transit-response]]
+    [reitit.ring :as ring]
     [ring.middleware.defaults :refer [wrap-defaults]]
     [ring.middleware.gzip :refer [wrap-gzip]]
+    [ring.middleware.session.memory :as mem]
     [ring.util.response :refer [response file-response resource-response]]
     [ring.util.response :as resp]
     [hiccup.page :refer [html5]]
@@ -19,20 +21,16 @@
      :headers {"Content-Type" "text/plain"}
      :body    "NOPE"}))
 
-(defn wrap-api [handler uri]
-  (fn [request]
-    (log/spy :info request)
-    (if (= uri (:uri request))
-      (handle-api-request
-        (:transit-params request)
-        (fn [tx] (parser {:ring/request request} tx)))
-      (handler request))))
+(defn api-handler [request]
+  (handle-api-request
+    (:transit-params request)
+    (fn [tx] (parser {:ring/request request} tx))))
 
 ;; ================================================================================
 ;; Dynamically generated HTML. We do this so we can safely embed the CSRF token
 ;; in a js var for use by the client.
 ;; ================================================================================
-(defn index []
+(defn index [{:keys [anti-forgery-token]}]
   (log/debug "Serving index.html")
   (html5
     [:html {:lang "en"}
@@ -42,32 +40,41 @@
       [:meta {:name "viewport" :content "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"}]
       [:link {:href "https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css"
               :rel  "stylesheet"}]
-      [:link {:rel "shortcut icon" :href "data:image/x-icon;," :type "image/x-icon"}]]
+      [:link {:rel "shortcut icon" :href "data:image/x-icon;," :type "image/x-icon"}]
+      [:script (str "var fulcro_network_csrf_token = '" anti-forgery-token "';")]]
      [:body
       [:div#app]
       [:script {:src "js/main/main.js"}]]]))
 
-(defn wrap-html-routes [ring-handler]
-  (fn [{:keys [uri] :as req}]
-    (cond
-      (#{"/" "/index.html"} uri)
-      (-> (resp/response (index))
-        (resp/content-type "text/html"))
-
-      :else
-      (ring-handler req))))
-
 (defstate middleware
   :start
-  (let [defaults-config (:ring.middleware/defaults-config config)]
-    (-> not-found-handler
-      (wrap-api "/api")
-      wrap-transit-params
-      wrap-transit-response
-      (wrap-html-routes)
-      ;; If you want to set something like session store, you'd do it against
-      ;; the defaults-config here (which comes from an EDN file, so it can't have
-      ;; code initialized).
-      ;; E.g. (wrap-defaults (assoc-in defaults-config [:session :store] (my-store)))
-      (wrap-defaults defaults-config)
-      wrap-gzip)))
+  (let [session-store          (mem/memory-store)
+        defaults-config        (-> (:ring.middleware/defaults-config config)
+                                 ;; If you want to set something like session store, you'd do it against
+                                 ;; the defaults-config here (which comes from an EDN file, so it can't have
+                                 ;; code initialized).
+                                 (assoc-in [:session :store] session-store))
+        defaults-config-native (-> defaults-config
+                                 ;; CSRF makes sense only in browser, so we disable it for native
+                                 ;; and change cookie name to prevent CSRF against this endpoint
+                                 (assoc-in [:security :anti-forgery] false)
+                                 (update-in [:session :cookie-name] str "-native"))]
+    (ring/ring-handler
+      (ring/router
+        [["/api"
+          {:middleware [#(wrap-defaults % defaults-config)
+                        wrap-transit-response
+                        wrap-transit-params]
+           :post       {:summary "Fulcro API"
+                        :handler api-handler}}]
+         ["/api-native"
+          {:middleware [#(wrap-defaults % defaults-config-native)
+                        wrap-transit-response
+                        wrap-transit-params]
+           :post       {:summary "Fulcro API for Native"
+                        :handler api-handler}}]])
+      (-> (fn [req]
+            (-> (resp/response (index req))
+              (resp/content-type "text/html")))
+        (wrap-defaults defaults-config))
+      {:middleware [wrap-gzip]})))

--- a/src/main/config/defaults.edn
+++ b/src/main/config/defaults.edn
@@ -28,8 +28,8 @@
                                           :default-charset        "utf-8"
                                           :not-modified-responses true}
                               :static    {:resources "public"}
-                              :session   true
-                              :security  {:anti-forgery   false
+                              :session   {:cookie-name "app-session"}
+                              :security  {:anti-forgery   true
                                           :hsts           true
                                           :ssl-redirect   false
                                           :frame-options  :sameorigin


### PR DESCRIPTION
What's in:
- moved API endpoint for native to /api-native (w/o CSRF and with different cookie)
- enabled CSRF for web /api
- enabled withCredentials XhrIo flag to be able to receive cookies in native
- updates Fulcro deps to the latest

Manually tested both web and native, from clean checkout.

Fulcro Inspect Electron won't work nicely due to Sente problem with RN env, would make a PR for websocket-preload customization, and then we could enable Inspect by default in native.