### PR TITLE
remove guardrails from dev jvm options 

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,6 +32,5 @@
                                com.fulcrologic/semantic-ui-wrapper {:mvn/version "1.0.0"}
                                binaryage/devtools                  {:mvn/version "0.9.10"}}}
            :dev  {:extra-paths ["src/dev"]
-                  :jvm-opts    ["-Dguardrails.enabled=true"]
                   :extra-deps  {org.clojure/tools.namespace {:mvn/version "0.3.1"}
                                 thheller/shadow-cljs        {:mvn/version "2.8.62"}}}}}


### PR DESCRIPTION
fixes issue with guardrails being included in shadow-cljs release

